### PR TITLE
Integrate SDK Kernel Patches 4.5.5142

### DIFF
--- a/patch/0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
+++ b/patch/0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
@@ -1,10 +1,7 @@
-From ab65c38369aec72cbaac3e1c9d6731804edfc5b4 Mon Sep 17 00:00:00 2001
+From a03e99d39f1943ec88f6fd3b0b9f34c20663d401 Mon Sep 17 00:00:00 2001
 From: Ido Schimmel <idosch@nvidia.com>
 Date: Sun, 14 Mar 2021 14:19:30 +0200
-
-[backport of upstream commit a03e99d39f1943ec88f6fd3b0b9f34c20663d401]
-
-Subject: [PATCH 1/3] psample: Encapsulate packet metadata in a struct
+Subject: [PATCH] psample: Encapsulate packet metadata in a struct
 
 Currently, callers of psample_sample_packet() pass three metadata
 attributes: Ingress port, egress port and truncated size. Subsequent
@@ -25,10 +22,10 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  4 files changed, 23 insertions(+), 21 deletions(-)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/spectrum.c b/drivers/net/ethernet/mellanox/mlxsw/spectrum.c
-index 1a9978f50..323857943 100644
+index 93b15b8c007e6d..3b15f8d728a37e 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/spectrum.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/spectrum.c
-@@ -2167,7 +2167,7 @@ void mlxsw_sp_sample_receive(struct mlxsw_sp *mlxsw_sp, struct sk_buff *skb,
+@@ -2217,7 +2217,7 @@ void mlxsw_sp_sample_receive(struct mlxsw_sp *mlxsw_sp, struct sk_buff *skb,
  {
  	struct mlxsw_sp_port *mlxsw_sp_port = mlxsw_sp->ports[local_port];
  	struct mlxsw_sp_port_sample *sample;
@@ -37,7 +34,7 @@ index 1a9978f50..323857943 100644
  
  	if (unlikely(!mlxsw_sp_port)) {
  		dev_warn_ratelimited(mlxsw_sp->bus_info->dev, "Port %d: sample skb received for non-existent port\n",
-@@ -2179,9 +2179,9 @@ void mlxsw_sp_sample_receive(struct mlxsw_sp *mlxsw_sp, struct sk_buff *skb,
+@@ -2229,9 +2229,9 @@ void mlxsw_sp_sample_receive(struct mlxsw_sp *mlxsw_sp, struct sk_buff *skb,
  	sample = rcu_dereference(mlxsw_sp_port->sample);
  	if (!sample)
  		goto out_unlock;
@@ -51,7 +48,7 @@ index 1a9978f50..323857943 100644
  	rcu_read_unlock();
  out:
 diff --git a/include/net/psample.h b/include/net/psample.h
-index 68ae16bb0..ac6dbfb38 100644
+index 68ae16bb0a4a85..ac6dbfb3870d94 100644
 --- a/include/net/psample.h
 +++ b/include/net/psample.h
 @@ -14,6 +14,12 @@ struct psample_group {
@@ -87,7 +84,7 @@ index 68ae16bb0..ac6dbfb38 100644
  }
  
 diff --git a/net/psample/psample.c b/net/psample/psample.c
-index 482c07f27..065bc887d 100644
+index 482c07f2766b18..065bc887d23936 100644
 --- a/net/psample/psample.c
 +++ b/net/psample/psample.c
 @@ -356,9 +356,11 @@ static int psample_tunnel_meta_len(struct ip_tunnel_info *tun_info)
@@ -105,7 +102,7 @@ index 482c07f27..065bc887d 100644
  	struct ip_tunnel_info *tun_info;
  #endif
 diff --git a/net/sched/act_sample.c b/net/sched/act_sample.c
-index 3ebf9ede3..2fece01f2 100644
+index db8ee9e5c8c229..6a0c16e4351d71 100644
 --- a/net/sched/act_sample.c
 +++ b/net/sched/act_sample.c
 @@ -158,10 +158,8 @@ static int tcf_sample_act(struct sk_buff *skb, const struct tc_action *a,
@@ -146,6 +143,3 @@ index 3ebf9ede3..2fece01f2 100644
  
  		if (skb_at_tc_ingress(skb) && tcf_sample_dev_ok_push(skb->dev))
  			skb_pull(skb, skb->mac_len);
--- 
-2.17.1
-

--- a/patch/0002-psample-Add-additional-metadata-attributes.patch
+++ b/patch/0002-psample-Add-additional-metadata-attributes.patch
@@ -1,10 +1,7 @@
-From d025a830ef465ea7b560742028b46dfc5c334cf1 Mon Sep 17 00:00:00 2001
+From 07e1a5809b595df6e125504dff6245cb2c8ed3de Mon Sep 17 00:00:00 2001
 From: Ido Schimmel <idosch@nvidia.com>
 Date: Sun, 14 Mar 2021 14:19:31 +0200
-
-[backport of upstream commit 07e1a5809b595df6e125504dff6245cb2c8ed3de]
-
-Subject: [PATCH 2/3] psample: Add additional metadata attributes
+Subject: [PATCH] psample: Add additional metadata attributes
 
 Extend psample to report the following attributes when available:
 
@@ -25,7 +22,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  3 files changed, 52 insertions(+), 1 deletion(-)
 
 diff --git a/include/net/psample.h b/include/net/psample.h
-index ac6dbfb38..e328c5127 100644
+index ac6dbfb3870d94..e328c512775717 100644
 --- a/include/net/psample.h
 +++ b/include/net/psample.h
 @@ -18,6 +18,13 @@ struct psample_metadata {
@@ -43,25 +40,24 @@ index ac6dbfb38..e328c5127 100644
  
  struct psample_group *psample_group_get(struct net *net, u32 group_num);
 diff --git a/include/uapi/linux/psample.h b/include/uapi/linux/psample.h
-index bff5032c9..0521691b6 100644
+index aea26ab1431c14..c6329f71b939fb 100644
 --- a/include/uapi/linux/psample.h
 +++ b/include/uapi/linux/psample.h
-@@ -13,6 +13,13 @@ enum {
+@@ -12,6 +12,12 @@ enum {
+ 	PSAMPLE_ATTR_DATA,
  	PSAMPLE_ATTR_GROUP_REFCOUNT,
  	PSAMPLE_ATTR_TUNNEL,
++    PSAMPLE_ATTR_PAD,
++	PSAMPLE_ATTR_OUT_TC,		/* u16 */
++	PSAMPLE_ATTR_OUT_TC_OCC,	/* u64, bytes */
++	PSAMPLE_ATTR_LATENCY,		/* u64, nanoseconds */
++	PSAMPLE_ATTR_TIMESTAMP,		/* u64, nanoseconds */
++	PSAMPLE_ATTR_PROTO,		/* u16 */
  
-+	PSAMPLE_ATTR_PAD,
-+	PSAMPLE_ATTR_OUT_TC,            /* u16 */
-+	PSAMPLE_ATTR_OUT_TC_OCC,        /* u64, bytes */
-+	PSAMPLE_ATTR_LATENCY,           /* u64, nanoseconds */
-+	PSAMPLE_ATTR_TIMESTAMP,         /* u64, nanoseconds */
-+	PSAMPLE_ATTR_PROTO,             /* u16 */
-+
  	__PSAMPLE_ATTR_MAX
  };
- 
 diff --git a/net/psample/psample.c b/net/psample/psample.c
-index 065bc887d..118d5d2a8 100644
+index 065bc887d23936..118d5d2a81a023 100644
 --- a/net/psample/psample.c
 +++ b/net/psample/psample.c
 @@ -8,6 +8,7 @@
@@ -134,6 +130,3 @@ index 065bc887d..118d5d2a8 100644
  	if (data_len) {
  		int nla_len = nla_total_size(data_len);
  		struct nlattr *nla;
--- 
-2.17.1
-

--- a/patch/0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
+++ b/patch/0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
@@ -1,28 +1,13 @@
-From 7dbf2689eb841c51dca4dad51b0941c06aa09e26 Mon Sep 17 00:00:00 2001
-From: Vadym Hlushko <vadymh@nvidia.com>
-Date: Mon, 11 Apr 2022 15:41:46 +0000
-Subject: [PATCH 3/3] psample: Add Nvidia-specific wrapper function for the psample driver
-
-Add a variable to notify the psample driver to use a wrapper function,
-which does preprocess before sending the sample packet to the userspace application.
-
-Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>
----
- include/net/psample.h | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/include/net/psample.h b/include/net/psample.h
-index e328c5127..b7c79f634 100644
+index e328c51..1c4d70c 100644
 --- a/include/net/psample.h
 +++ b/include/net/psample.h
 @@ -14,6 +14,8 @@ struct psample_group {
  	struct rcu_head rcu;
  };
-
-+#define PSAMPLE_MD_EXTENDED_ATTR   1
+ 
++#define PSAMPLE_MD_EXTENDED_ATTR 1
 +
  struct psample_metadata {
  	u32 trunc_size;
  	int in_ifindex;
--- 
-2.17.1

--- a/patch/series
+++ b/patch/series
@@ -64,6 +64,9 @@ kernel-compat-always-include-linux-compat.h-from-net-compat.patch
 
 # Mellanox patches for 5.10
 ###-> mellanox_sdk-start
+0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
+0002-psample-Add-additional-metadata-attributes.patch
+0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
 ###-> mellanox_sdk-end
 
 ###-> mellanox_hw_mgmt-start
@@ -184,9 +187,6 @@ cisco-hwmon-pmbus_core-pec-support-check.patch
 0001-hwmon-emc2305-Fix-unable-to-probe-emc2301-2-3.patch
 
 # sFlow + dropmon support
-0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
-0002-psample-Add-additional-metadata-attributes.patch
-0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
 
 #
 # Marvell platform patches for 5.10


### PR DESCRIPTION
#### Why I did it

Integrate SDK 4.5.5142 Kernel Patches

 ## Patch List
* 0001-psample-Encapsulate-packet-metadata-in-a-struct.patch : https://github.com/torvalds/linux/commit/a03e99d39f1943ec88f6fd3b0b9f34c20663d401
* 0002-psample-Add-additional-metadata-attributes.patch : https://github.com/torvalds/linux/commit/07e1a5809b595df6e125504dff6245cb2c8ed3de
* 0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch :


#### How I did it

Run make integrate-mlnx-hw-mgmt



