### PR TITLE
Add drop monitor Kernel Patches for buffer support

### DIFF
--- a/patch/0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
+++ b/patch/0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
@@ -1,10 +1,7 @@
-From ab65c38369aec72cbaac3e1c9d6731804edfc5b4 Mon Sep 17 00:00:00 2001
+From a03e99d39f1943ec88f6fd3b0b9f34c20663d401 Mon Sep 17 00:00:00 2001
 From: Ido Schimmel <idosch@nvidia.com>
 Date: Sun, 14 Mar 2021 14:19:30 +0200
-
-[backport of upstream commit a03e99d39f1943ec88f6fd3b0b9f34c20663d401]
-
-Subject: [PATCH 1/3] psample: Encapsulate packet metadata in a struct
+Subject: [PATCH] psample: Encapsulate packet metadata in a struct
 
 Currently, callers of psample_sample_packet() pass three metadata
 attributes: Ingress port, egress port and truncated size. Subsequent
@@ -25,10 +22,10 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  4 files changed, 23 insertions(+), 21 deletions(-)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/spectrum.c b/drivers/net/ethernet/mellanox/mlxsw/spectrum.c
-index 1a9978f50..323857943 100644
+index 93b15b8c007e6d..3b15f8d728a37e 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/spectrum.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/spectrum.c
-@@ -2167,7 +2167,7 @@ void mlxsw_sp_sample_receive(struct mlxsw_sp *mlxsw_sp, struct sk_buff *skb,
+@@ -2217,7 +2217,7 @@ void mlxsw_sp_sample_receive(struct mlxsw_sp *mlxsw_sp, struct sk_buff *skb,
  {
  	struct mlxsw_sp_port *mlxsw_sp_port = mlxsw_sp->ports[local_port];
  	struct mlxsw_sp_port_sample *sample;
@@ -37,7 +34,7 @@ index 1a9978f50..323857943 100644
  
  	if (unlikely(!mlxsw_sp_port)) {
  		dev_warn_ratelimited(mlxsw_sp->bus_info->dev, "Port %d: sample skb received for non-existent port\n",
-@@ -2179,9 +2179,9 @@ void mlxsw_sp_sample_receive(struct mlxsw_sp *mlxsw_sp, struct sk_buff *skb,
+@@ -2229,9 +2229,9 @@ void mlxsw_sp_sample_receive(struct mlxsw_sp *mlxsw_sp, struct sk_buff *skb,
  	sample = rcu_dereference(mlxsw_sp_port->sample);
  	if (!sample)
  		goto out_unlock;
@@ -51,7 +48,7 @@ index 1a9978f50..323857943 100644
  	rcu_read_unlock();
  out:
 diff --git a/include/net/psample.h b/include/net/psample.h
-index 68ae16bb0..ac6dbfb38 100644
+index 68ae16bb0a4a85..ac6dbfb3870d94 100644
 --- a/include/net/psample.h
 +++ b/include/net/psample.h
 @@ -14,6 +14,12 @@ struct psample_group {
@@ -87,7 +84,7 @@ index 68ae16bb0..ac6dbfb38 100644
  }
  
 diff --git a/net/psample/psample.c b/net/psample/psample.c
-index 482c07f27..065bc887d 100644
+index 482c07f2766b18..065bc887d23936 100644
 --- a/net/psample/psample.c
 +++ b/net/psample/psample.c
 @@ -356,9 +356,11 @@ static int psample_tunnel_meta_len(struct ip_tunnel_info *tun_info)
@@ -105,7 +102,7 @@ index 482c07f27..065bc887d 100644
  	struct ip_tunnel_info *tun_info;
  #endif
 diff --git a/net/sched/act_sample.c b/net/sched/act_sample.c
-index 3ebf9ede3..2fece01f2 100644
+index db8ee9e5c8c229..6a0c16e4351d71 100644
 --- a/net/sched/act_sample.c
 +++ b/net/sched/act_sample.c
 @@ -158,10 +158,8 @@ static int tcf_sample_act(struct sk_buff *skb, const struct tc_action *a,
@@ -146,6 +143,3 @@ index 3ebf9ede3..2fece01f2 100644
  
  		if (skb_at_tc_ingress(skb) && tcf_sample_dev_ok_push(skb->dev))
  			skb_pull(skb, skb->mac_len);
--- 
-2.17.1
-

--- a/patch/0002-psample-Add-additional-metadata-attributes.patch
+++ b/patch/0002-psample-Add-additional-metadata-attributes.patch
@@ -1,10 +1,7 @@
-From d025a830ef465ea7b560742028b46dfc5c334cf1 Mon Sep 17 00:00:00 2001
+From 07e1a5809b595df6e125504dff6245cb2c8ed3de Mon Sep 17 00:00:00 2001
 From: Ido Schimmel <idosch@nvidia.com>
 Date: Sun, 14 Mar 2021 14:19:31 +0200
-
-[backport of upstream commit 07e1a5809b595df6e125504dff6245cb2c8ed3de]
-
-Subject: [PATCH 2/3] psample: Add additional metadata attributes
+Subject: [PATCH] psample: Add additional metadata attributes
 
 Extend psample to report the following attributes when available:
 
@@ -25,7 +22,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  3 files changed, 52 insertions(+), 1 deletion(-)
 
 diff --git a/include/net/psample.h b/include/net/psample.h
-index ac6dbfb38..e328c5127 100644
+index ac6dbfb3870d94..e328c512775717 100644
 --- a/include/net/psample.h
 +++ b/include/net/psample.h
 @@ -18,6 +18,13 @@ struct psample_metadata {
@@ -43,25 +40,24 @@ index ac6dbfb38..e328c5127 100644
  
  struct psample_group *psample_group_get(struct net *net, u32 group_num);
 diff --git a/include/uapi/linux/psample.h b/include/uapi/linux/psample.h
-index bff5032c9..0521691b6 100644
+index aea26ab1431c14..c6329f71b939fb 100644
 --- a/include/uapi/linux/psample.h
 +++ b/include/uapi/linux/psample.h
-@@ -13,6 +13,13 @@ enum {
+@@ -12,6 +12,12 @@ enum {
+ 	PSAMPLE_ATTR_DATA,
  	PSAMPLE_ATTR_GROUP_REFCOUNT,
  	PSAMPLE_ATTR_TUNNEL,
++    PSAMPLE_ATTR_PAD,
++	PSAMPLE_ATTR_OUT_TC,		/* u16 */
++	PSAMPLE_ATTR_OUT_TC_OCC,	/* u64, bytes */
++	PSAMPLE_ATTR_LATENCY,		/* u64, nanoseconds */
++	PSAMPLE_ATTR_TIMESTAMP,		/* u64, nanoseconds */
++	PSAMPLE_ATTR_PROTO,		/* u16 */
  
-+	PSAMPLE_ATTR_PAD,
-+	PSAMPLE_ATTR_OUT_TC,            /* u16 */
-+	PSAMPLE_ATTR_OUT_TC_OCC,        /* u64, bytes */
-+	PSAMPLE_ATTR_LATENCY,           /* u64, nanoseconds */
-+	PSAMPLE_ATTR_TIMESTAMP,         /* u64, nanoseconds */
-+	PSAMPLE_ATTR_PROTO,             /* u16 */
-+
  	__PSAMPLE_ATTR_MAX
  };
- 
 diff --git a/net/psample/psample.c b/net/psample/psample.c
-index 065bc887d..118d5d2a8 100644
+index 065bc887d23936..118d5d2a81a023 100644
 --- a/net/psample/psample.c
 +++ b/net/psample/psample.c
 @@ -8,6 +8,7 @@
@@ -134,6 +130,3 @@ index 065bc887d..118d5d2a8 100644
  	if (data_len) {
  		int nla_len = nla_total_size(data_len);
  		struct nlattr *nla;
--- 
-2.17.1
-

--- a/patch/0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
+++ b/patch/0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
@@ -1,28 +1,13 @@
-From 7dbf2689eb841c51dca4dad51b0941c06aa09e26 Mon Sep 17 00:00:00 2001
-From: Vadym Hlushko <vadymh@nvidia.com>
-Date: Mon, 11 Apr 2022 15:41:46 +0000
-Subject: [PATCH 3/3] psample: Add Nvidia-specific wrapper function for the psample driver
-
-Add a variable to notify the psample driver to use a wrapper function,
-which does preprocess before sending the sample packet to the userspace application.
-
-Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>
----
- include/net/psample.h | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/include/net/psample.h b/include/net/psample.h
-index e328c5127..b7c79f634 100644
+index e328c51..1c4d70c 100644
 --- a/include/net/psample.h
 +++ b/include/net/psample.h
 @@ -14,6 +14,8 @@ struct psample_group {
  	struct rcu_head rcu;
  };
-
-+#define PSAMPLE_MD_EXTENDED_ATTR   1
+ 
++#define PSAMPLE_MD_EXTENDED_ATTR 1
 +
  struct psample_metadata {
  	u32 trunc_size;
  	int in_ifindex;
--- 
-2.17.1

--- a/patch/0004-drop_monitor-Extend-WJH-buffer-linux-channel.patch
+++ b/patch/0004-drop_monitor-Extend-WJH-buffer-linux-channel.patch
@@ -1,0 +1,230 @@
+From 1eee33e3c2c47fe2ca9dbad0712c0686ecdbf60a Mon Sep 17 00:00:00 2001
+From: Zhengfeng Dou <zhengfengd@nvidia.com>
+Date: Thu, 29 Jun 2023 12:15:19 +0800
+Subject: [PATCH] drop_monitor: Extend WJH buffer linux channel
+
+---
+ include/net/devlink.h            |  18 +++++
+ include/uapi/linux/net_dropmon.h |   5 ++
+ net/core/drop_monitor.c          | 111 +++++++++++++++++++++++++++++++
+ 3 files changed, 134 insertions(+)
+
+diff --git a/include/net/devlink.h b/include/net/devlink.h
+index b01bb9bca..e81314255 100644
+--- a/include/net/devlink.h
++++ b/include/net/devlink.h
+@@ -20,6 +20,10 @@
+ #include <uapi/linux/devlink.h>
+ #include <linux/xarray.h>
+ 
++#ifndef SX_EXTEND_WJH_BUFFER_LINUX_CHANNEL
++#define SX_EXTEND_WJH_BUFFER_LINUX_CHANNEL
++#endif
++
+ #define DEVLINK_RELOAD_STATS_ARRAY_SIZE \
+ 	(__DEVLINK_RELOAD_LIMIT_MAX * __DEVLINK_RELOAD_ACTION_MAX)
+ 
+@@ -665,6 +669,11 @@ struct devlink_health_reporter_ops {
+  * @input_dev: Input netdevice.
+  * @fa_cookie: Flow action user cookie.
+  * @trap_type: Trap type.
++ * @output_port_dev: Output port netdevice.
++ * @output_lag_dev: Output lag netdevice.
++ * @out_tc: Output port tclass.
++ * @out_tc_occ: Output port tclass buffer occupancy.
++ * @latency: End-to-end latency.
+  */
+ struct devlink_trap_metadata {
+ 	const char *trap_name;
+@@ -672,6 +681,15 @@ struct devlink_trap_metadata {
+ 	struct net_device *input_dev;
+ 	const struct flow_action_cookie *fa_cookie;
+ 	enum devlink_trap_type trap_type;
++	struct net_device *output_port_dev;
++	struct net_device *output_lag_dev;
++	u16 out_tc;
++	u64 out_tc_occ;
++	u64 latency;
++	u8 out_tc_valid:1,
++	   out_tc_occ_valid:1,
++	   latency_valid:1,
++	   unused:5;
+ };
+ 
+ /**
+diff --git a/include/uapi/linux/net_dropmon.h b/include/uapi/linux/net_dropmon.h
+index 66048cc5d..6afabc7a7 100644
+--- a/include/uapi/linux/net_dropmon.h
++++ b/include/uapi/linux/net_dropmon.h
+@@ -93,6 +93,11 @@ enum net_dm_attr {
+ 	NET_DM_ATTR_SW_DROPS,			/* flag */
+ 	NET_DM_ATTR_HW_DROPS,			/* flag */
+ 	NET_DM_ATTR_FLOW_ACTION_COOKIE,		/* binary */
++	NET_DM_ATTR_OUT_PORT,			/* nested */
++	NET_DM_ATTR_OUT_LAG,			/* nested */
++	NET_DM_ATTR_OUT_TC,			/* u16 */
++	NET_DM_ATTR_OUT_TC_OCC,			/* u64 */
++	NET_DM_ATTR_LATENCY,			/* u64 */
+ 
+ 	__NET_DM_ATTR_MAX,
+ 	NET_DM_ATTR_MAX = __NET_DM_ATTR_MAX - 1
+diff --git a/net/core/drop_monitor.c b/net/core/drop_monitor.c
+index db65ce62b..940d88b8b 100644
+--- a/net/core/drop_monitor.c
++++ b/net/core/drop_monitor.c
+@@ -599,6 +599,36 @@ static int net_dm_packet_report_in_port_put(struct sk_buff *msg, int ifindex,
+ 	return -EMSGSIZE;
+ }
+ 
++static int net_dm_packet_report_out_port_put(struct sk_buff *msg, int ifindex,
++					    const char *name, bool is_lag)
++{
++	struct nlattr *attr;
++	int            attrtype = NET_DM_ATTR_OUT_PORT;
++
++	if (is_lag) {
++		attrtype = NET_DM_ATTR_OUT_LAG;
++	}
++
++	attr = nla_nest_start(msg, attrtype);
++	if (!attr)
++		return -EMSGSIZE;
++
++	if (ifindex &&
++	    nla_put_u32(msg, NET_DM_ATTR_PORT_NETDEV_IFINDEX, ifindex))
++		goto nla_put_failure;
++
++	if (name && nla_put_string(msg, NET_DM_ATTR_PORT_NETDEV_NAME, name))
++		goto nla_put_failure;
++
++	nla_nest_end(msg, attr);
++
++	return 0;
++
++nla_put_failure:
++	nla_nest_cancel(msg, attr);
++	return -EMSGSIZE;
++}
++
+ static int net_dm_packet_report_fill(struct sk_buff *msg, struct sk_buff *skb,
+ 				     size_t payload_len)
+ {
+@@ -717,6 +747,16 @@ net_dm_flow_action_cookie_size(const struct devlink_trap_metadata *hw_metadata)
+ 	       nla_total_size(hw_metadata->fa_cookie->cookie_len) : 0;
+ }
+ 
++static size_t net_dm_out_port_size(void)
++{
++	       /* NET_DM_ATTR_OUT_PORT nest */
++	return nla_total_size(0) +
++	       /* NET_DM_ATTR_PORT_NETDEV_IFINDEX */
++	       nla_total_size(sizeof(u32)) +
++	       /* NET_DM_ATTR_PORT_NETDEV_NAME */
++	       nla_total_size(IFNAMSIZ + 1);
++}
++
+ static size_t
+ net_dm_hw_packet_report_size(size_t payload_len,
+ 			     const struct devlink_trap_metadata *hw_metadata)
+@@ -742,6 +782,16 @@ net_dm_hw_packet_report_size(size_t payload_len,
+ 	       nla_total_size(sizeof(u32)) +
+ 	       /* NET_DM_ATTR_PROTO */
+ 	       nla_total_size(sizeof(u16)) +
++	       /* NET_DM_ATTR_OUT_PORT */
++	       net_dm_out_port_size() +
++	       /* NET_DM_ATTR_OUT_LAG */
++	       net_dm_out_port_size() +
++	       /* NET_DM_ATTR_OUT_TC */
++	       nla_total_size(sizeof(u16)) +
++	       /* NET_DM_ATTR_OUT_TC_OCC */
++	       nla_total_size(sizeof(u64)) +
++	       /* NET_DM_ATTR_LATENCY */
++	       nla_total_size(sizeof(u64)) +
+ 	       /* NET_DM_ATTR_PAYLOAD */
+ 	       nla_total_size(payload_len);
+ }
+@@ -787,6 +837,43 @@ static int net_dm_hw_packet_report_fill(struct sk_buff *msg,
+ 		    hw_metadata->fa_cookie->cookie))
+ 		goto nla_put_failure;
+ 
++	if (hw_metadata->output_port_dev) {
++		struct net_device *dev = hw_metadata->output_port_dev;
++		int rc;
++
++		rc = net_dm_packet_report_out_port_put(msg, dev->ifindex,
++						      dev->name, false);
++		if (rc)
++			goto nla_put_failure;
++	}
++
++	if (hw_metadata->output_lag_dev) {
++		struct net_device *dev = hw_metadata->output_lag_dev;
++		int rc;
++
++		rc = net_dm_packet_report_out_port_put(msg, dev->ifindex,
++						      dev->name, true);
++		if (rc)
++			goto nla_put_failure;
++	}
++
++	if (hw_metadata->out_tc_valid) {
++		if (nla_put_u16(msg, NET_DM_ATTR_OUT_TC, hw_metadata->out_tc))
++			goto nla_put_failure;
++	}
++
++	if (hw_metadata->out_tc_occ_valid) {
++		if (nla_put_u64_64bit(msg, NET_DM_ATTR_OUT_TC_OCC,
++		              hw_metadata->out_tc_occ, NET_DM_ATTR_PAD))
++			goto nla_put_failure;
++	}
++
++	if (hw_metadata->latency_valid) {
++		if (nla_put_u64_64bit(msg, NET_DM_ATTR_LATENCY,
++		              hw_metadata->latency, NET_DM_ATTR_PAD))
++			goto nla_put_failure;
++	}
++
+ 	if (nla_put_u64_64bit(msg, NET_DM_ATTR_TIMESTAMP,
+ 			      ktime_to_ns(skb->tstamp), NET_DM_ATTR_PAD))
+ 		goto nla_put_failure;
+@@ -853,6 +940,26 @@ net_dm_hw_metadata_copy(const struct devlink_trap_metadata *metadata)
+ 	if (hw_metadata->input_dev)
+ 		dev_hold(hw_metadata->input_dev);
+ 
++	hw_metadata->output_port_dev = metadata->output_port_dev;
++	if (hw_metadata->output_port_dev)
++		dev_hold(hw_metadata->output_port_dev);
++
++	hw_metadata->output_lag_dev = metadata->output_lag_dev;
++	if (hw_metadata->output_lag_dev)
++		dev_hold(hw_metadata->output_lag_dev);
++
++	hw_metadata->out_tc_valid = metadata->out_tc_valid;
++	if (hw_metadata->out_tc_valid)
++		hw_metadata->out_tc = metadata->out_tc;
++
++	hw_metadata->out_tc_occ_valid = metadata->out_tc_occ_valid;
++	if (hw_metadata->out_tc_occ_valid)
++		hw_metadata->out_tc_occ = metadata->out_tc_occ;
++
++	hw_metadata->latency_valid = metadata->latency_valid;
++	if (hw_metadata->latency_valid)
++		hw_metadata->latency = metadata->latency;
++
+ 	return hw_metadata;
+ 
+ free_trap_name:
+@@ -869,6 +976,10 @@ net_dm_hw_metadata_free(const struct devlink_trap_metadata *hw_metadata)
+ {
+ 	if (hw_metadata->input_dev)
+ 		dev_put(hw_metadata->input_dev);
++	if (hw_metadata->output_port_dev)
++		dev_put(hw_metadata->output_port_dev);
++	if (hw_metadata->output_lag_dev)
++		dev_put(hw_metadata->output_lag_dev);
+ 	kfree(hw_metadata->fa_cookie);
+ 	kfree(hw_metadata->trap_name);
+ 	kfree(hw_metadata->trap_group_name);
+-- 
+2.30.2
+

--- a/patch/series
+++ b/patch/series
@@ -67,6 +67,10 @@ kernel-compat-always-include-linux-compat.h-from-net-compat.patch
 
 # Mellanox patches for 5.10
 ###-> mellanox_sdk-start
+0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
+0002-psample-Add-additional-metadata-attributes.patch
+0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
+0004-drop_monitor-Extend-WJH-buffer-linux-channel.patch
 ###-> mellanox_sdk-end
 
 ###-> mellanox_hw_mgmt-start
@@ -193,9 +197,6 @@ cisco-hwmon-pmbus_core-pec-support-check.patch
 0001-hwmon-emc2305-Fix-unable-to-probe-emc2301-2-3.patch
 
 # sFlow + dropmon support
-0001-psample-Encapsulate-packet-metadata-in-a-struct.patch
-0002-psample-Add-additional-metadata-attributes.patch
-0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
 
 #
 # Marvell platform patches for 5.10


### PR DESCRIPTION
Add the new patch 0004-drop_monitor-Extend-WJH-buffer-linux-channel.patch and move the patch names under the markers 

 ## Patch List
* 0001-psample-Encapsulate-packet-metadata-in-a-struct.patch : https://github.com/torvalds/linux/commit/a03e99d39f1943ec88f6fd3b0b9f34c20663d401
* 0002-psample-Add-additional-metadata-attributes.patch : https://github.com/torvalds/linux/commit/07e1a5809b595df6e125504dff6245cb2c8ed3de
* 0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch :
* 0004-drop_monitor-Extend-WJH-buffer-linux-channel.patch :