### PR TITLE
Add nvidia arm markers and add an ability to patch kconfig-inc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ DSC_FILE_URL = "$(SOURCE_FILE_BASE_URL)/$(DSC_FILE)"
 DEBIAN_FILE_URL = "$(SOURCE_FILE_BASE_URL)/$(DEBIAN_FILE)"
 ORIG_FILE_URL = "$(SOURCE_FILE_BASE_URL)/$(ORIG_FILE)"
 NON_UP_DIR = /tmp/non_upstream_patches
+KCFG_INCL = kconfig-inclusions
+SERIES = series
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Include any non upstream patches
@@ -77,19 +79,25 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 		fi
 	fi
 
-	if [ -f "$(NON_UP_DIR)/series.patch" ]; then
-		echo "Patch the series file"
-		cat $(NON_UP_DIR)/series.patch
-		pushd patch
-		# clear any unstaged changes
-		git stash -- series
-		git apply $(NON_UP_DIR)/series.patch
-		popd
+	pushd patch
+	if [ -f "$(NON_UP_DIR)/$(SERIES).patch" ]; then
+		echo "Patch the $(SERIES) file"
+		cat $(NON_UP_DIR)/$(SERIES).patch
+		git stash -- $(SERIES)
+		git apply $(NON_UP_DIR)/$(SERIES).patch
+	fi
 
-		if [ -d "$(NON_UP_DIR)/patches" ]; then
-			echo "Copy the non upstream patches"
-			cp $(NON_UP_DIR)/patches/*.patch patch/
-		fi
+	if [ -f "$(NON_UP_DIR)/$(KCFG_INCL).patch" ]; then
+		echo "Patch the $(KCFG_INCL) file"
+		cat $(NON_UP_DIR)/$(KCFG_INCL).patch
+		git stash -- $(KCFG_INCL)
+		git apply $(NON_UP_DIR)/$(KCFG_INCL).patch
+	fi
+	popd
+
+	if [ -d "$(NON_UP_DIR)/patches" ]; then
+		echo "Copy the non upstream patches"
+		cp $(NON_UP_DIR)/patches/*.patch patch/
 	fi
 
 	# Obtaining the Debian kernel source

--- a/manage-config
+++ b/manage-config
@@ -159,7 +159,9 @@ exclusion_file="../patch/kconfig-exclusions"
 inclusion_file="../patch/kconfig-inclusions"
 force_inclusion_file="../patch/kconfig-force-inclusions"
 ret_process_inc_ex=0
-ret_process_inc_ex=$(process_inclusion_exclusion_files > /dev/null; echo $?)
+log_process_inc_ex=$(mktemp -t /tmp/process_inc_ex_XXXX.log)
+ret_process_inc_ex=$(process_inclusion_exclusion_files > ${log_process_inc_ex}; echo $?)
+cat ${log_process_inc_ex}
 
 #  Secure Boot support
 if [ $ret_process_inc_ex -eq 0 ]; then
@@ -179,11 +181,13 @@ if [ $ret_process_inc_ex -eq 0 ]; then
         # save the new pub key in kernel
         sed -i "s|^CONFIG_SYSTEM_TRUSTED_KEYS=.*|CONFIG_SYSTEM_TRUSTED_KEYS=\"$SECURE_UPGRADE_SIGNING_CERT\"|g" ${inclusion_file}
 
-        ret_process_inc_ex=$(process_inclusion_exclusion_files > /dev/null; echo $?)
+        ret_process_inc_ex=$(process_inclusion_exclusion_files > ${log_process_inc_ex}; echo $?)
         echo "Secure Boot kernel configuration done."
+        cat ${log_process_inc_ex}
     else
         echo "no Secure Boot Kernel configuration required."
     fi
 fi
 
+rm -rf ${log_process_inc_ex}
 exit $ret_process_inc_ex

--- a/manage-config
+++ b/manage-config
@@ -159,7 +159,7 @@ exclusion_file="../patch/kconfig-exclusions"
 inclusion_file="../patch/kconfig-inclusions"
 force_inclusion_file="../patch/kconfig-force-inclusions"
 ret_process_inc_ex=0
-log_process_inc_ex=$(mktemp -t /tmp/process_inc_ex_XXXX.log)
+log_process_inc_ex=$(mktemp -t process_inc_ex_log.XXXXX)
 ret_process_inc_ex=$(process_inclusion_exclusion_files > ${log_process_inc_ex}; echo $?)
 cat ${log_process_inc_ex}
 

--- a/patch/kconfig-exclusions
+++ b/patch/kconfig-exclusions
@@ -13,8 +13,8 @@ CONFIG_CGROUP_NET_PRIO
 # Unset X86_PAT according to Broadcom's requirement
 CONFIG_X86_PAT
 CONFIG_MLXSW_PCI
-###-> mellanox-start
-###-> mellanox-end
+###-> mellanox_amd64-start
+###-> mellanox_amd64-end
 
 [arm64]
 CONFIG_SQUASHFS_DECOMP_MULTI_PERCPU

--- a/patch/kconfig-exclusions
+++ b/patch/kconfig-exclusions
@@ -6,14 +6,20 @@ CONFIG_CGROUP_NET_CLASSID
 CONFIG_NET_CLS_CGROUP
 CONFIG_NETFILTER_XT_MATCH_CGROUP
 CONFIG_CGROUP_NET_PRIO
+###-> mellanox_common-start
+###-> mellanox_common-end
 
 [amd64]
 # Unset X86_PAT according to Broadcom's requirement
 CONFIG_X86_PAT
 CONFIG_MLXSW_PCI
+###-> mellanox-start
+###-> mellanox-end
 
 [arm64]
 CONFIG_SQUASHFS_DECOMP_MULTI_PERCPU
+###-> mellanox_arm64-start
+###-> mellanox_arm64-end
 
 [marvell-arm64]
 CONFIG_UBIFS_FS_ZSTD

--- a/patch/kconfig-inclusions
+++ b/patch/kconfig-inclusions
@@ -6,6 +6,8 @@
 
 [common]
 CONFIG_LOG_BUF_SHIFT=20
+###-> mellanox_common-start
+###-> mellanox_common-end
 
 [amd64]
 # For Arista
@@ -158,6 +160,8 @@ CONFIG_SPI_INTEL_SPI_PLATFORM=m
 CONFIG_SPI_INTEL_SPI=m
 
 [arm64]
+###-> mellanox_arm64-start
+###-> mellanox_arm64-end
 # For Marvell
 CONFIG_EEPROM_SFF_8436=m
 CONFIG_EEPROM_OPTOE=m

--- a/patch/kconfig-inclusions
+++ b/patch/kconfig-inclusions
@@ -39,7 +39,7 @@ CONFIG_SENSORS_MAX31790=m
 # For optoe
 CONFIG_EEPROM_OPTOE=m
 
-###-> mellanox-start
+###-> mellanox_amd64-start
 CONFIG_OF=y
 CONFIG_THERMAL_OF=y
 CONFIG_CPU_THERMAL=y
@@ -140,7 +140,7 @@ CONFIG_I2C_I801=m
 CONFIG_PINCTRL=y
 CONFIG_PINCTRL_INTEL=y
 CONFIG_SPI_PXA2XX=m
-###-> mellanox-end
+###-> mellanox_amd64-end
 
 # For Cisco 8000
 CONFIG_PHYLIB=m


### PR DESCRIPTION
1) Add non-amd64 nvidia markers 
2) Add an ability to patch kconfig-inclusions file
3) Fix the bug in manage-config script where the output of the process_inclusion_exclusion_files method is not shown in the log file since it is redirected to /dev/null