### PR TITLE
Integrate SDK Kernel Patches 4.6.2104

### DIFF
--- a/patch/0001-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
+++ b/patch/0001-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
@@ -12,7 +12,7 @@ Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/include/net/psample.h b/include/net/psample.h
-index e328c51..1c4d70c 100644
+index 0509d2d..c66e325 100644
 --- a/include/net/psample.h
 +++ b/include/net/psample.h
 @@ -14,6 +14,8 @@ struct psample_group {

--- a/patch/0002-drop_monitor-Extend-WJH-buffer-linux-channel.patch
+++ b/patch/0002-drop_monitor-Extend-WJH-buffer-linux-channel.patch
@@ -20,22 +20,22 @@ This patch is to add the extended information also for linux channel.
  3 files changed, 134 insertions(+)
 
 diff --git a/include/net/devlink.h b/include/net/devlink.h
-index b01bb9bca..e81314255 100644
+index ba6b8b0..214edcc 100644
 --- a/include/net/devlink.h
 +++ b/include/net/devlink.h
-@@ -20,6 +20,10 @@
- #include <uapi/linux/devlink.h>
+@@ -21,6 +21,10 @@
  #include <linux/xarray.h>
+ #include <linux/firmware.h>
  
 +#ifndef SX_EXTEND_WJH_BUFFER_LINUX_CHANNEL
 +#define SX_EXTEND_WJH_BUFFER_LINUX_CHANNEL
 +#endif
 +
- #define DEVLINK_RELOAD_STATS_ARRAY_SIZE \
- 	(__DEVLINK_RELOAD_LIMIT_MAX * __DEVLINK_RELOAD_ACTION_MAX)
+ struct devlink;
+ struct devlink_linecard;
  
-@@ -665,6 +669,11 @@ struct devlink_health_reporter_ops {
-  * @input_dev: Input netdevice.
+@@ -711,6 +715,11 @@ struct devlink_health_reporter_ops {
+  * @dev_tracker: refcount tracker for @input_dev.
   * @fa_cookie: Flow action user cookie.
   * @trap_type: Trap type.
 + * @output_port_dev: Output port netdevice.
@@ -46,8 +46,8 @@ index b01bb9bca..e81314255 100644
   */
  struct devlink_trap_metadata {
  	const char *trap_name;
-@@ -672,6 +681,15 @@ struct devlink_trap_metadata {
- 	struct net_device *input_dev;
+@@ -721,6 +730,15 @@ struct devlink_trap_metadata {
+ 
  	const struct flow_action_cookie *fa_cookie;
  	enum devlink_trap_type trap_type;
 +	struct net_device *output_port_dev;
@@ -63,13 +63,13 @@ index b01bb9bca..e81314255 100644
  
  /**
 diff --git a/include/uapi/linux/net_dropmon.h b/include/uapi/linux/net_dropmon.h
-index 66048cc5d..6afabc7a7 100644
+index 84f622a..d6f6399 100644
 --- a/include/uapi/linux/net_dropmon.h
 +++ b/include/uapi/linux/net_dropmon.h
-@@ -93,6 +93,11 @@ enum net_dm_attr {
- 	NET_DM_ATTR_SW_DROPS,			/* flag */
+@@ -94,6 +94,11 @@ enum net_dm_attr {
  	NET_DM_ATTR_HW_DROPS,			/* flag */
  	NET_DM_ATTR_FLOW_ACTION_COOKIE,		/* binary */
+ 	NET_DM_ATTR_REASON,			/* string */
 +	NET_DM_ATTR_OUT_PORT,			/* nested */
 +	NET_DM_ATTR_OUT_LAG,			/* nested */
 +	NET_DM_ATTR_OUT_TC,			/* u16 */
@@ -79,10 +79,10 @@ index 66048cc5d..6afabc7a7 100644
  	__NET_DM_ATTR_MAX,
  	NET_DM_ATTR_MAX = __NET_DM_ATTR_MAX - 1
 diff --git a/net/core/drop_monitor.c b/net/core/drop_monitor.c
-index db65ce62b..940d88b8b 100644
+index f084a4a..0405e10 100644
 --- a/net/core/drop_monitor.c
 +++ b/net/core/drop_monitor.c
-@@ -599,6 +599,36 @@ static int net_dm_packet_report_in_port_put(struct sk_buff *msg, int ifindex,
+@@ -606,6 +606,36 @@ nla_put_failure:
  	return -EMSGSIZE;
  }
  
@@ -119,7 +119,7 @@ index db65ce62b..940d88b8b 100644
  static int net_dm_packet_report_fill(struct sk_buff *msg, struct sk_buff *skb,
  				     size_t payload_len)
  {
-@@ -717,6 +747,16 @@ net_dm_flow_action_cookie_size(const struct devlink_trap_metadata *hw_metadata)
+@@ -731,6 +761,16 @@ net_dm_flow_action_cookie_size(const struct devlink_trap_metadata *hw_metadata)
  	       nla_total_size(hw_metadata->fa_cookie->cookie_len) : 0;
  }
  
@@ -136,7 +136,7 @@ index db65ce62b..940d88b8b 100644
  static size_t
  net_dm_hw_packet_report_size(size_t payload_len,
  			     const struct devlink_trap_metadata *hw_metadata)
-@@ -742,6 +782,16 @@ net_dm_hw_packet_report_size(size_t payload_len,
+@@ -756,6 +796,16 @@ net_dm_hw_packet_report_size(size_t payload_len,
  	       nla_total_size(sizeof(u32)) +
  	       /* NET_DM_ATTR_PROTO */
  	       nla_total_size(sizeof(u16)) +
@@ -153,7 +153,7 @@ index db65ce62b..940d88b8b 100644
  	       /* NET_DM_ATTR_PAYLOAD */
  	       nla_total_size(payload_len);
  }
-@@ -787,6 +837,43 @@ static int net_dm_hw_packet_report_fill(struct sk_buff *msg,
+@@ -801,6 +851,43 @@ static int net_dm_hw_packet_report_fill(struct sk_buff *msg,
  		    hw_metadata->fa_cookie->cookie))
  		goto nla_put_failure;
  
@@ -197,44 +197,42 @@ index db65ce62b..940d88b8b 100644
  	if (nla_put_u64_64bit(msg, NET_DM_ATTR_TIMESTAMP,
  			      ktime_to_ns(skb->tstamp), NET_DM_ATTR_PAD))
  		goto nla_put_failure;
-@@ -853,6 +940,26 @@ net_dm_hw_metadata_copy(const struct devlink_trap_metadata *metadata)
- 	if (hw_metadata->input_dev)
- 		dev_hold(hw_metadata->input_dev);
+@@ -867,6 +954,27 @@ net_dm_hw_metadata_copy(const struct devlink_trap_metadata *metadata)
+ 	netdev_hold(hw_metadata->input_dev, &hw_metadata->dev_tracker,
+ 		    GFP_ATOMIC);
  
-+	hw_metadata->output_port_dev = metadata->output_port_dev;
-+	if (hw_metadata->output_port_dev)
-+		dev_hold(hw_metadata->output_port_dev);
++       hw_metadata->output_port_dev = metadata->output_port_dev;
++       if (hw_metadata->output_port_dev)
++               netdev_hold(hw_metadata->output_port_dev, &hw_metadata->dev_tracker, GFP_ATOMIC);
 +
-+	hw_metadata->output_lag_dev = metadata->output_lag_dev;
-+	if (hw_metadata->output_lag_dev)
-+		dev_hold(hw_metadata->output_lag_dev);
++       hw_metadata->output_lag_dev = metadata->output_lag_dev;
++       if (hw_metadata->output_lag_dev)
++               netdev_hold(hw_metadata->output_lag_dev, &hw_metadata->dev_tracker, GFP_ATOMIC);
 +
-+	hw_metadata->out_tc_valid = metadata->out_tc_valid;
-+	if (hw_metadata->out_tc_valid)
-+		hw_metadata->out_tc = metadata->out_tc;
++       hw_metadata->out_tc_valid = metadata->out_tc_valid;
++       if (hw_metadata->out_tc_valid)
++               hw_metadata->out_tc = metadata->out_tc;
 +
-+	hw_metadata->out_tc_occ_valid = metadata->out_tc_occ_valid;
-+	if (hw_metadata->out_tc_occ_valid)
-+		hw_metadata->out_tc_occ = metadata->out_tc_occ;
++       hw_metadata->out_tc_occ_valid = metadata->out_tc_occ_valid;
 +
-+	hw_metadata->latency_valid = metadata->latency_valid;
-+	if (hw_metadata->latency_valid)
-+		hw_metadata->latency = metadata->latency;
++       if (hw_metadata->out_tc_occ_valid)
++               hw_metadata->out_tc_occ = metadata->out_tc_occ;
++
++       hw_metadata->latency_valid = metadata->latency_valid;
++       if (hw_metadata->latency_valid)
++               hw_metadata->latency = metadata->latency;
 +
  	return hw_metadata;
  
  free_trap_name:
-@@ -869,6 +976,10 @@ net_dm_hw_metadata_free(const struct devlink_trap_metadata *hw_metadata)
+@@ -882,6 +990,10 @@ static void
+ net_dm_hw_metadata_free(struct devlink_trap_metadata *hw_metadata)
  {
- 	if (hw_metadata->input_dev)
- 		dev_put(hw_metadata->input_dev);
-+	if (hw_metadata->output_port_dev)
-+		dev_put(hw_metadata->output_port_dev);
-+	if (hw_metadata->output_lag_dev)
-+		dev_put(hw_metadata->output_lag_dev);
+ 	netdev_put(hw_metadata->input_dev, &hw_metadata->dev_tracker);
++       if (hw_metadata->output_port_dev)
++               netdev_put(hw_metadata->output_port_dev, &hw_metadata->dev_tracker);
++       if (hw_metadata->output_lag_dev)
++               netdev_put(hw_metadata->output_lag_dev, &hw_metadata->dev_tracker);
  	kfree(hw_metadata->fa_cookie);
  	kfree(hw_metadata->trap_name);
  	kfree(hw_metadata->trap_group_name);
--- 
-2.30.2
-

--- a/patch/series
+++ b/patch/series
@@ -68,8 +68,8 @@ driver-net-tg3-add-param-short-preamble-and-reset.patch
 
 # Mellanox patches for 5.10
 ###-> mellanox_sdk-start
-0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
-0004-drop_monitor-Extend-WJH-buffer-linux-channel.patch
+0001-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch
+0002-drop_monitor-Extend-WJH-buffer-linux-channel.patch
 ###-> mellanox_sdk-end
 
 #TODO


### PR DESCRIPTION
#### Why I did it

Integrate SDK 4.6.2104 Kernel Patches

 ## Patch List
* 0001-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch :
* 0002-drop_monitor-Extend-WJH-buffer-linux-channel.patch :


#### How I did it
Run make integrate-mlnx-hw-mgmt

